### PR TITLE
add type input for button, default is submit

### DIFF
--- a/projects/example-app/src/app/form-page/form-page.component.html
+++ b/projects/example-app/src/app/form-page/form-page.component.html
@@ -51,9 +51,10 @@
 
   <h2>Input - inline form</h2>
   <mui-panel>
-    <form class="mui-form--inline" [formGroup]="inlineForm" (ngSubmit)="resetInlineForm()">
+    <form class="mui-form--inline" [formGroup]="inlineForm" (ngSubmit)="submitInlineForm()">
       <mui-input id="inlineField" formControlName="inlineText" placeholder="Placeholder 1"></mui-input>
-      <mui-button variant="flat">Submit</mui-button>
+      <mui-button variant="raised" color="primary">Submit</mui-button>
+      <mui-button type="button" variant="flat" color="primary" (click)="resetInlineForm()">Cancel</mui-button>
     </form>
   </mui-panel>
 

--- a/projects/example-app/src/app/form-page/form-page.component.ts
+++ b/projects/example-app/src/app/form-page/form-page.component.ts
@@ -97,4 +97,10 @@ export class FormPageComponent {
         this.inlineForm.reset();
     }
 
+    // reset inline form
+    submitInlineForm(): void {
+        console.log('submit inline form: ', this.inlineForm.value);
+        this.inlineForm.reset();
+    }
+
 }

--- a/projects/mui-angular/button/button.component.ts
+++ b/projects/mui-angular/button/button.component.ts
@@ -3,7 +3,7 @@ import { Component, ElementRef, Input, ViewChild, Renderer2, AfterViewInit } fro
 @Component({
   selector: 'mui-button',
   template: `
-    <button class="mui-btn" muiRipple #button [disabled]="disabled">
+    <button type={{type}} class="mui-btn" muiRipple #button [disabled]="disabled">
       <ng-content></ng-content>
       <span class="mui-btn__ripple-container"><span class="mui-ripple" #ripple></span></span>
     </button>
@@ -17,6 +17,7 @@ export class ButtonComponent implements AfterViewInit {
   @Input() color?: string;
   @Input() size?: string;
   @Input() disabled?: boolean = false;
+  @Input() type?: 'button' | 'reset' | 'submit' = 'submit';
 
   private buttonEl: HTMLButtonElement;
 


### PR DESCRIPTION
Without a type attribute, Angular would sometime interpret a click on a cancel button as a submit event.  A type attribute defaulting to submit has been added to the button component.